### PR TITLE
refactor: simplify Maven groupId to org.codelibs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.codelibs.xerces</groupId>
+	<groupId>org.codelibs</groupId>
 	<artifactId>xerces</artifactId>
 	<packaging>jar</packaging>
 	<version>3.0.0-SNAPSHOT</version>


### PR DESCRIPTION
## Summary

This PR simplifies the Maven groupId from `org.codelibs.xerces` to `org.codelibs` to align with standard CodeLibs artifact naming conventions.

## Changes Made

- Modified `pom.xml` to change groupId from `org.codelibs.xerces` to `org.codelibs`
- This change maintains consistency with other CodeLibs projects and simplifies dependency declarations

## Impact

- **Breaking Change**: Yes - Projects depending on this artifact will need to update their dependency declarations
- The artifactId remains `xerces`, so the full Maven coordinates become `org.codelibs:xerces:3.0.0-SNAPSHOT`

## Migration Guide

For projects using this library, update Maven dependencies from:
```xml
<dependency>
    <groupId>org.codelibs.xerces</groupId>
    <artifactId>xerces</artifactId>
</dependency>
```

To:
```xml
<dependency>
    <groupId>org.codelibs</groupId>
    <artifactId>xerces</artifactId>
</dependency>
```

## Testing

- Build verification: `mvn clean install` completes successfully
- No functional changes - purely metadata update