### PR TITLE
chore(build): bump central-publishing-maven-plugin to 0.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>central</publishingServerId>


### PR DESCRIPTION
## Summary

Bumps `org.sonatype.central:central-publishing-maven-plugin` from `0.7.0` to `0.11.0`.

## Details

The plugin is declared in the main `<build><plugins>` section with `<extensions>true</extensions>`, so it is loaded as a build extension on every Maven invocation, not only during releases.

The existing `<configuration>` only sets `<publishingServerId>`, which is unchanged across this version range, so no configuration updates are required.

## Verification

- `0.11.0` is the current release on Maven Central and resolves successfully.
- `mvn validate` passes with the new extension version loaded.
